### PR TITLE
Add projects from other repo as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "open-quantum-hardware"]
+	path = open-quantum-hardware
+	url = https://github.com/nathanshammah/open-quantum-hardware.git

--- a/_config.yml
+++ b/_config.yml
@@ -50,6 +50,7 @@ minima:
 header_pages:
   - index.md
   - program.md
+  - open-quantum-hardware/projects.md
 
 # Build settings
 theme: minima


### PR DESCRIPTION
Add projects from the https://github.com/nathanshammah/open-quantum-hardware repo as a submodule of this one, to show them in the website.